### PR TITLE
Fix for Github link not working

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -127,7 +127,7 @@
                 <p class="subtitle is-size-4">About</p>
                 <p>
                   Made by <a href="https://jonahsnider.ninja">Jonah Snider</a> and <a
-                    href="https://github/MicroDroid">OverCoder</a>
+                    href="https://github.com/MicroDroid">OverCoder</a>
                 </p>
                 <p><a
                     href="https://www.producthunt.com/posts/zero-width-shortener?utm_source=badge-top-post-badge&amp;utm_medium=badge&amp;utm_souce=badge-zero-width-shortener"


### PR DESCRIPTION
Having a quick look at the site. The `.com` on GitHub Link was missing. :) 